### PR TITLE
Basic implementations of each service

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(main main.cc ${csi-spec_SOURCE})
+add_executable(main main.cc service.cc ${csi-spec_SOURCE})
 target_include_directories(main PRIVATE ${csi-spec_INCLUDE_DIR})
 target_link_libraries(main grpc++ grpc++_reflection cxxopts protobuf::libprotobuf)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_executable(main main.cc service.cc ${csi-spec_SOURCE})
+add_executable(main
+    main.cc
+    service.cc
+    node_service.cc
+    ${csi_proto_srcs}
+    ${csi_grpc_srcs}
+)
 target_include_directories(main PRIVATE ${csi-spec_INCLUDE_DIR})
-target_link_libraries(main grpc++ grpc++_reflection cxxopts libprotobuf)
+target_link_libraries(main grpc++ grpc++_reflection cxxopts protobuf::libprotobuf)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(main
     main.cc
     service.cc
     node_service.cc
+    identity_service.cc
     ${csi_proto_srcs}
     ${csi_grpc_srcs}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(main
     service.cc
     node_service.cc
     identity_service.cc
+    controller_service.cc
     ${csi_proto_srcs}
     ${csi_grpc_srcs}
 )

--- a/src/controller_service.cc
+++ b/src/controller_service.cc
@@ -1,0 +1,111 @@
+#include "controller_service.h"
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+namespace csi::service::controller {
+ControllerService::ControllerService() {}
+ControllerService::~ControllerService() {}
+
+grpc::Status ControllerService::CreateVolume(
+    grpc::ServerContext *context, const csi::v1::CreateVolumeRequest *request,
+    csi::v1::CreateVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::DeleteVolume(
+    grpc::ServerContext *context, const csi::v1::DeleteVolumeRequest *request,
+    csi::v1::DeleteVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::ControllerPublishVolume(
+    grpc::ServerContext *context,
+    const csi::v1::ControllerPublishVolumeRequest *request,
+    csi::v1::ControllerPublishVolumeResponse *response) {
+  return grpc::Status::CANCELLED;
+}
+
+grpc::Status ControllerService::ControllerUnpublishVolume(
+    grpc::ServerContext *context,
+    const csi::v1::ControllerUnpublishVolumeRequest *request,
+    csi::v1::ControllerUnpublishVolumeResponse *response) {
+  return grpc::Status::CANCELLED;
+}
+
+grpc::Status ControllerService::ValidateVolumeCapabilities(
+    grpc::ServerContext *context,
+    const csi::v1::ValidateVolumeCapabilitiesRequest *request,
+    csi::v1::ValidateVolumeCapabilitiesResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::ListVolumes(
+    grpc::ServerContext *context, const csi::v1::ListVolumesRequest *request,
+    csi::v1::ListVolumesResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::GetCapacity(
+    grpc::ServerContext *context, const csi::v1::GetCapacityRequest *request,
+    csi::v1::GetCapacityResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::ControllerGetCapabilities(
+    grpc::ServerContext *context,
+    const csi::v1::ControllerGetCapabilitiesRequest *request,
+    csi::v1::ControllerGetCapabilitiesResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::CreateSnapshot(
+    grpc::ServerContext *context, const csi::v1::CreateSnapshotRequest *request,
+    csi::v1::CreateSnapshotResponse *response) {
+  return grpc::Status::CANCELLED;
+}
+
+grpc::Status ControllerService::DeleteSnapshot(
+    grpc::ServerContext *context, const csi::v1::DeleteSnapshotRequest *request,
+    csi::v1::DeleteSnapshotResponse *response) {
+  return grpc::Status::CANCELLED;
+}
+
+grpc::Status ControllerService::ListSnapshots(
+    grpc::ServerContext *context, const csi::v1::ListSnapshotsRequest *request,
+    csi::v1::ListSnapshotsResponse) {
+  return grpc::Status::CANCELLED;
+}
+
+grpc::Status ControllerService::ControllerExpandVolume(
+    grpc::ServerContext *context,
+    const csi::v1::ControllerExpandVolumeRequest *request,
+    csi::v1::ControllerExpandVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status ControllerService::ControllerGetVolume(
+    grpc::ServerContext *context,
+    const csi::v1::ControllerGetVolumeRequest *request,
+    csi::v1::ControllerGetVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+bool ControllerService::IsControllerServiceRequestValid(
+    csi::v1::ControllerServiceCapability_RPC_Type serviceType) const {
+  for (auto const cap : GetControllerServiceCapabilities()) {
+    if (cap == serviceType) return true;
+  }
+  return false;
+}
+
+std::vector<csi::v1::ControllerServiceCapability_RPC_Type>
+ControllerService::GetControllerServiceCapabilities() const {
+  using cap = csi::v1::ControllerServiceCapability::RPC::Type;
+  return std::vector<csi::v1::ControllerServiceCapability_RPC_Type>{
+      cap::ControllerServiceCapability_RPC_Type_CREATE_DELETE_VOLUME,
+      cap::ControllerServiceCapability_RPC_Type_LIST_VOLUMES,
+      cap::ControllerServiceCapability_RPC_Type_GET_CAPACITY,
+      cap::ControllerServiceCapability_RPC_Type_GET_VOLUME};
+}
+}  // namespace csi::service::controller

--- a/src/controller_service.h
+++ b/src/controller_service.h
@@ -1,0 +1,71 @@
+#ifndef CSI_DRIVER_CHFS_CONTROLLER_SERVICE_H_
+#define CSI_DRIVER_CHFS_CONTROLLER_SERVICE_H_
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+#include <vector>
+
+namespace csi::service::controller {
+class ControllerService final : public csi::v1::Controller::Service {
+ public:
+  ControllerService();
+  ~ControllerService();
+
+  grpc::Status CreateVolume(grpc::ServerContext *context,
+                            const csi::v1::CreateVolumeRequest *request,
+                            csi::v1::CreateVolumeResponse *response) override;
+  grpc::Status DeleteVolume(grpc::ServerContext *context,
+                            const csi::v1::DeleteVolumeRequest *request,
+                            csi::v1::DeleteVolumeResponse *response) override;
+  grpc::Status ControllerPublishVolume(
+      grpc::ServerContext *context,
+      const csi::v1::ControllerPublishVolumeRequest *request,
+      csi::v1::ControllerPublishVolumeResponse *response) override;
+  grpc::Status ControllerUnpublishVolume(
+      grpc::ServerContext *context,
+      const csi::v1::ControllerUnpublishVolumeRequest *request,
+      csi::v1::ControllerUnpublishVolumeResponse *response) override;
+  grpc::Status ValidateVolumeCapabilities(
+      grpc::ServerContext *context,
+      const csi::v1::ValidateVolumeCapabilitiesRequest *request,
+      csi::v1::ValidateVolumeCapabilitiesResponse *response) override;
+  grpc::Status ListVolumes(grpc::ServerContext *context,
+                           const csi::v1::ListVolumesRequest *request,
+                           csi::v1::ListVolumesResponse *response) override;
+  grpc::Status GetCapacity(grpc::ServerContext *context,
+                           const csi::v1::GetCapacityRequest *request,
+                           csi::v1::GetCapacityResponse *response) override;
+  grpc::Status ControllerGetCapabilities(
+      grpc::ServerContext *context,
+      const csi::v1::ControllerGetCapabilitiesRequest *request,
+      csi::v1::ControllerGetCapabilitiesResponse *response) override;
+  grpc::Status CreateSnapshot(
+      grpc::ServerContext *context,
+      const csi::v1::CreateSnapshotRequest *request,
+      csi::v1::CreateSnapshotResponse *response) override;
+  grpc::Status DeleteSnapshot(
+      grpc::ServerContext *context,
+      const csi::v1::DeleteSnapshotRequest *request,
+      csi::v1::DeleteSnapshotResponse *response) override;
+  grpc::Status ListSnapshots(grpc::ServerContext *context,
+                             const csi::v1::ListSnapshotsRequest *request,
+                             csi::v1::ListSnapshotsResponse);
+  grpc::Status ControllerExpandVolume(
+      grpc::ServerContext *context,
+      const csi::v1::ControllerExpandVolumeRequest *request,
+      csi::v1::ControllerExpandVolumeResponse *response) override;
+  grpc::Status ControllerGetVolume(
+      grpc::ServerContext *context,
+      const csi::v1::ControllerGetVolumeRequest *request,
+      csi::v1::ControllerGetVolumeResponse *response) override;
+
+ private:
+  bool IsControllerServiceRequestValid(
+      csi::v1::ControllerServiceCapability_RPC_Type serviceType) const;
+  std::vector<csi::v1::ControllerServiceCapability_RPC_Type>
+  GetControllerServiceCapabilities() const;
+};
+}  // namespace csi::service::controller
+
+#endif  // CSI_DRIVER_CHFS_CONTROLLER_SERVICE_H_

--- a/src/identity_service.cc
+++ b/src/identity_service.cc
@@ -1,0 +1,34 @@
+#include "identity_service.h"
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+namespace csi::service::identity {
+IdentityService::IdentityService() {}
+IdentityService::~IdentityService() {}
+
+grpc::Status IdentityService::GetPluginInfo(
+    grpc::ServerContext *context, const csi::v1::GetPluginInfoRequest *request,
+    csi::v1::GetPluginInfoResponse *response) {
+  response->set_name("csi-driver-chfs");
+  response->set_vendor_version("0.0.1");
+  return grpc::Status::OK;
+}
+
+grpc::Status IdentityService::GetPluginCapabilities(
+    grpc::ServerContext *context,
+    const csi::v1::GetPluginCapabilitiesRequest *request,
+    csi::v1::GetPluginCapabilitiesResponse *response) {
+  auto *capability = response->mutable_capabilities()->Add();
+  capability->mutable_service()->set_type(
+      csi::v1::PluginCapability::Service::Type::
+          PluginCapability_Service_Type_CONTROLLER_SERVICE);
+  return grpc::Status::OK;
+}
+
+grpc::Status IdentityService::Probe(grpc::ServerContext *context,
+                                    const csi::v1::ProbeRequest *request,
+                                    csi::v1::ProbeResponse *response) {
+  return grpc::Status::OK;
+}
+}  // namespace csi::service::identity

--- a/src/identity_service.h
+++ b/src/identity_service.h
@@ -1,0 +1,26 @@
+#ifndef CSI_DRIVER_CHFS_IDENTITY_SERVICE_H_
+#define CSI_DRIVER_CHFS_IDENTITY_SERVICE_H_
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+namespace csi::service::identity {
+class IdentityService final : public csi::v1::Identity::Service {
+ public:
+  IdentityService();
+  ~IdentityService();
+
+  grpc::Status GetPluginInfo(grpc::ServerContext *context,
+                             const csi::v1::GetPluginInfoRequest *request,
+                             csi::v1::GetPluginInfoResponse *response) override;
+  grpc::Status GetPluginCapabilities(
+      grpc::ServerContext *context,
+      const csi::v1::GetPluginCapabilitiesRequest *request,
+      csi::v1::GetPluginCapabilitiesResponse *response) override;
+  grpc::Status Probe(grpc::ServerContext *context,
+                     const csi::v1::ProbeRequest *request,
+                     csi::v1::ProbeResponse *response) override;
+};
+}  // namespace csi::service::identity
+
+#endif  // CSI_DRIVER_CHFS_IDENTITY_SERVICE_H_

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,36 +1,33 @@
-#include <iostream>
-#include <fstream>
-
 #include <csi.pb.h>
+#include <grpc/support/log.h>
+#include <grpcpp/grpcpp.h>
 
 #include <cxxopts.hpp>
+#include <fstream>
+#include <iostream>
 
 const std::string VERSION_FILE = "VERSION";
 
-int main(int argc, char **argv)
-{
-    cxxopts::Options options("chfsplugin", "CSI driver for CHFS");
-    options.add_options()("h,help", "Print this message")("v,version", "version");
+int main(int argc, char **argv) {
+  cxxopts::Options options("chfsplugin", "CSI driver for CHFS");
+  options.add_options()("h,help", "Print this message")("v,version", "version");
 
-    auto parsed = options.parse(argc, argv);
-    if (parsed.count("help"))
-    {
-        std::cout << options.help() << std::endl;
-        exit(0);
+  auto parsed = options.parse(argc, argv);
+  if (parsed.count("help")) {
+    std::cout << options.help() << std::endl;
+    exit(0);
+  }
+  if (parsed.count("version")) {
+    std::ifstream ifs(VERSION_FILE);
+    std::string version;
+    if (ifs.fail()) {
+      std::cout << "version file \'" << VERSION_FILE << "\' does not found"
+                << std::endl;
+      exit(1);
     }
-    if (parsed.count("version"))
-    {
-        std::ifstream ifs(VERSION_FILE);
-        std::string version;
-        if (ifs.fail())
-        {
-            std::cout << "version file \'" << VERSION_FILE << "\' does not found" << std::endl;
-            exit(1);
-        }
-        while (getline(ifs, version))
-        {
-            std::cout << version << std::endl;
-            exit(0);
-        }
+    while (getline(ifs, version)) {
+      std::cout << version << std::endl;
+      exit(0);
     }
+  }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,16 +1,20 @@
-#include <csi.pb.h>
-#include <grpc/support/log.h>
-#include <grpcpp/grpcpp.h>
-
 #include <cxxopts.hpp>
 #include <fstream>
 #include <iostream>
+
+#include "service.h"
 
 const std::string VERSION_FILE = "VERSION";
 
 int main(int argc, char **argv) {
   cxxopts::Options options("chfsplugin", "CSI driver for CHFS");
-  options.add_options()("h,help", "Print this message")("v,version", "version");
+  // clang-format off
+  options.add_options()
+    ("h,help", "Print this message")
+    ("v,version", "version")
+    ("e,endpoint", "CSI endpoint",
+      cxxopts::value<std::string>()->default_value("unix://tmp/csi.sock"))
+  ;
 
   auto parsed = options.parse(argc, argv);
   if (parsed.count("help")) {
@@ -30,4 +34,10 @@ int main(int argc, char **argv) {
       exit(0);
     }
   }
+
+  csi::service::Config config;
+  config.endpoint() = parsed["endpoint"].as<std::string>();
+
+  csi::service::Server server(config);
+  server.Run();
 }

--- a/src/node_service.cc
+++ b/src/node_service.cc
@@ -1,0 +1,64 @@
+#include "node_service.h"
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+namespace node = csi::service::node;
+
+node::NodeService::NodeService() {}
+node::NodeService::~NodeService() {}
+
+grpc::Status node::NodeService::NodeGetInfo(
+    grpc::ServerContext *context, const csi::v1::NodeGetInfoRequest *request,
+    csi::v1::NodeGetInfoResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeStageVolume(
+    grpc::ServerContext *context,
+    const csi::v1::NodeStageVolumeRequest *request,
+    csi::v1::NodeStageVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeUnstageVolume(
+    grpc::ServerContext *context,
+    const csi::v1::NodeUnstageVolumeRequest *request,
+    csi::v1::NodeUnstageVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodePublishVolume(
+    grpc::ServerContext *context,
+    const csi::v1::NodePublishVolumeRequest *request,
+    csi::v1::NodePublishVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeUnpublishVolume(
+    grpc::ServerContext *context,
+    const csi::v1::NodeUnpublishVolumeRequest *request,
+    csi::v1::NodeUnpublishVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeGetVolumeStats(
+    grpc::ServerContext *context,
+    const csi::v1::NodeGetVolumeStatsRequest *request,
+    csi::v1::NodeGetVolumeStatsResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeExpandVolume(
+    grpc::ServerContext *context,
+    const csi::v1::NodeExpandVolumeRequest *request,
+    csi::v1::NodeExpandVolumeResponse *response) {
+  return grpc::Status::OK;
+}
+
+grpc::Status node::NodeService::NodeGetCapabilities(
+    grpc::ServerContext *context,
+    const csi::v1::NodeGetCapabilitiesRequest *request,
+    csi::v1::NodeGetCapabilitiesResponse *response) {
+  return grpc::Status::OK;
+}

--- a/src/node_service.h
+++ b/src/node_service.h
@@ -1,0 +1,47 @@
+#ifndef CSI_DRIVER_CHFS_NODE_SERVICE_H_
+#define CSI_DRIVER_CHFS_NODE_SERVICE_H_
+
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
+namespace csi::service::node {
+class NodeService final : public csi::v1::Node::Service {
+ public:
+  NodeService();
+  ~NodeService();
+
+  grpc::Status NodeGetInfo(grpc::ServerContext *context,
+                           const csi::v1::NodeGetInfoRequest *request,
+                           csi::v1::NodeGetInfoResponse *response) override;
+  grpc::Status NodeStageVolume(
+      grpc::ServerContext *context,
+      const csi::v1::NodeStageVolumeRequest *request,
+      csi::v1::NodeStageVolumeResponse *response) override;
+  grpc::Status NodeUnstageVolume(
+      grpc::ServerContext *context,
+      const csi::v1::NodeUnstageVolumeRequest *request,
+      csi::v1::NodeUnstageVolumeResponse *response) override;
+  grpc::Status NodePublishVolume(
+      grpc::ServerContext *context,
+      const csi::v1::NodePublishVolumeRequest *request,
+      csi::v1::NodePublishVolumeResponse *response) override;
+  grpc::Status NodeUnpublishVolume(
+      grpc::ServerContext *context,
+      const csi::v1::NodeUnpublishVolumeRequest *request,
+      csi::v1::NodeUnpublishVolumeResponse *response) override;
+  grpc::Status NodeGetVolumeStats(
+      grpc::ServerContext *context,
+      const csi::v1::NodeGetVolumeStatsRequest *request,
+      csi::v1::NodeGetVolumeStatsResponse *response) override;
+  grpc::Status NodeExpandVolume(
+      grpc::ServerContext *context,
+      const csi::v1::NodeExpandVolumeRequest *request,
+      csi::v1::NodeExpandVolumeResponse *response) override;
+  grpc::Status NodeGetCapabilities(
+      grpc::ServerContext *context,
+      const csi::v1::NodeGetCapabilitiesRequest *request,
+      csi::v1::NodeGetCapabilitiesResponse *response) override;
+};
+}  // namespace csi::service::node
+
+#endif  // CSI_DRIVER_CHFS_NODE_SERVICE_H_

--- a/src/service.cc
+++ b/src/service.cc
@@ -1,0 +1,25 @@
+#include "service.h"
+
+#include <grpc/grpc.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+
+namespace csi {
+namespace service {
+Config::Config() {}
+Config::~Config() {}
+Server::Server(Config config) : config_(config) {}
+Server::~Server() {}
+
+void Server::Run() {
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(config().endpoint(),
+                           grpc::InsecureServerCredentials());
+
+  std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  server->Wait();
+}
+}  // namespace service
+}  // namespace csi

--- a/src/service.cc
+++ b/src/service.cc
@@ -6,6 +6,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "identity_service.h"
 #include "node_service.h"
 
 namespace csi {
@@ -19,10 +20,11 @@ void Server::Run() {
   grpc::ServerBuilder builder;
   builder.AddListeningPort(config().endpoint(),
                            grpc::InsecureServerCredentials());
-
   node::NodeService node_service;
+  identity::IdentityService identity_service;
 
   builder.RegisterService(&node_service);
+  builder.RegisterService(&identity_service);
 
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
   std::cout << "Listening on " << config().endpoint() << std::endl;

--- a/src/service.cc
+++ b/src/service.cc
@@ -6,6 +6,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "node_service.h"
+
 namespace csi {
 namespace service {
 Config::Config() {}
@@ -18,7 +20,12 @@ void Server::Run() {
   builder.AddListeningPort(config().endpoint(),
                            grpc::InsecureServerCredentials());
 
+  node::NodeService node_service;
+
+  builder.RegisterService(&node_service);
+
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  std::cout << "Listening on " << config().endpoint() << std::endl;
   server->Wait();
 }
 }  // namespace service

--- a/src/service.h
+++ b/src/service.h
@@ -1,0 +1,33 @@
+#ifndef CSI_DRIVER_CHFS_SERVICE_HPP_
+#define CSI_DRIVER_CHFS_SERVICE_HPP_
+
+#include <string>
+
+namespace csi {
+namespace service {
+class Config {
+ public:
+  Config();
+  ~Config();
+
+  std::string &endpoint() { return endpoint_; }
+  const std::string &endpoint() const { return endpoint_; }
+
+ private:
+  std::string endpoint_;
+};
+class Server {
+ public:
+  Server(Config config);
+  ~Server();
+  void Run();
+
+  Config &config() { return config_; }
+  const Config &config() const { return config_; }
+
+ private:
+  Config config_;
+};
+}  // namespace service
+}  // namespace csi
+#endif  // CSI_DRIVER_CHFS_SERVICE_HPP_


### PR DESCRIPTION
## 概要

Node, Controller, Identity それぞれのサービスのインターフェースの実装を用意した。
インターフェースを実装しただけなので、中身は無い。

## 変更内容

* 各サービスの実装
    - node
    - controller
    - identity
* endpoint をCLIで指定できるように変更
    - unit test (csi-sanity) で利用する

## Test

identity のみ pass している。

```
Ran 77 of 84 Specs in 2.714 seconds
FAIL! -- 3 Passed | 74 Failed | 1 Pending | 6 Skipped
```