### PR TITLE
NodeGetInfo の実装

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -3,8 +3,11 @@
 namespace csi {
 namespace service {
 Config::Config(const std::string endpoint, const std::string driver_name,
-               const std::string version)
-    : endpoint_(endpoint), driver_name_(driver_name), version_(version) {}
+               const std::string node_id, const std::string version)
+    : endpoint_(endpoint),
+      driver_name_(driver_name),
+      node_id_(node_id),
+      version_(version) {}
 Config::~Config() {}
 }  // namespace service
 }  // namespace csi

--- a/src/config.h
+++ b/src/config.h
@@ -8,16 +8,18 @@ namespace service {
 class Config {
  public:
   Config(const std::string endpoint, const std::string driver_name,
-         const std::string version);
+         const std::string node_id, const std::string version);
   ~Config();
 
   const std::string &driver_name() const { return driver_name_; }
   const std::string &endpoint() const { return endpoint_; }
+  const std::string &node_id() const { return node_id_; }
   const std::string &version() const { return version_; }
 
  private:
   std::string driver_name_;
   std::string endpoint_;
+  std::string node_id_;
   std::string version_;
 };
 

--- a/src/controller_service.h
+++ b/src/controller_service.h
@@ -11,7 +11,9 @@
 namespace csi::service::controller {
 class ControllerService final : public csi::v1::Controller::Service {
  public:
-  ControllerService(const csi::service::Config &config);
+  ControllerService(
+      const csi::service::Config &config,
+      std::vector<csi::v1::ControllerServiceCapability_RPC_Type> capabilities);
   ~ControllerService();
 
   grpc::Status CreateVolume(grpc::ServerContext *context,
@@ -64,10 +66,9 @@ class ControllerService final : public csi::v1::Controller::Service {
 
  private:
   csi::service::Config const &config_;
+  std::vector<csi::v1::ControllerServiceCapability_RPC_Type> capabilities_;
   bool IsControllerServiceRequestValid(
       csi::v1::ControllerServiceCapability_RPC_Type serviceType) const;
-  std::vector<csi::v1::ControllerServiceCapability_RPC_Type>
-  GetControllerServiceCapabilities() const;
 };
 }  // namespace csi::service::controller
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -41,6 +41,8 @@ int main(int argc, char **argv) {
       cxxopts::value<std::string>()->default_value("unix://tmp/csi.sock"))
     ("n,driver-name", "name of this CSI driver",
       cxxopts::value<std::string>()->default_value("chfsplugin"))
+    ("i,node-id", "node id",
+      cxxopts::value<std::string>()->default_value(""))
   ;
 
   auto parsed = options.parse(argc, argv);
@@ -57,8 +59,9 @@ int main(int argc, char **argv) {
 
   const std::string endpoint = parsed["endpoint"].as<std::string>();
   const std::string driver_name = parsed["driver-name"].as<std::string>();
+  const std::string node_id = parsed["node-id"].as<std::string>();
   const std::string version = GetVersion(VERSION_FILE);
-  csi::service::Config config(endpoint, driver_name, version);
+  csi::service::Config config(endpoint, driver_name, node_id, version);
 
   csi::service::Server server(config);
   server.Run();

--- a/src/node_service.cc
+++ b/src/node_service.cc
@@ -7,8 +7,10 @@
 
 namespace node = csi::service::node;
 
-node::NodeService::NodeService(const csi::service::Config &config)
-    : config_(config) {}
+node::NodeService::NodeService(
+    const csi::service::Config &config,
+    std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities)
+    : config_(config), capabilities_(capabilities) {}
 node::NodeService::~NodeService() {}
 
 grpc::Status node::NodeService::NodeStageVolume(

--- a/src/node_service.cc
+++ b/src/node_service.cc
@@ -63,5 +63,6 @@ grpc::Status node::NodeService::NodeGetCapabilities(
 grpc::Status node::NodeService::NodeGetInfo(
     grpc::ServerContext *context, const csi::v1::NodeGetInfoRequest *request,
     csi::v1::NodeGetInfoResponse *response) {
+  response->set_node_id(config_.node_id());
   return grpc::Status::OK;
 }

--- a/src/node_service.cc
+++ b/src/node_service.cc
@@ -9,7 +9,7 @@ namespace node = csi::service::node;
 
 node::NodeService::NodeService(
     const csi::service::Config &config,
-    std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities)
+    std::vector<csi::v1::NodeServiceCapability_RPC_Type> capabilities)
     : config_(config), capabilities_(capabilities) {}
 node::NodeService::~NodeService() {}
 

--- a/src/node_service.h
+++ b/src/node_service.h
@@ -9,7 +9,9 @@
 namespace csi::service::node {
 class NodeService final : public csi::v1::Node::Service {
  public:
-  NodeService(csi::service::Config const &config);
+  NodeService(
+      csi::service::Config const &config,
+      std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities);
   NodeService(const NodeService &) = delete;
   NodeService &operator=(const NodeService &) = delete;
   ~NodeService();
@@ -48,6 +50,7 @@ class NodeService final : public csi::v1::Node::Service {
 
  private:
   csi::service::Config const &config_;
+  std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities_;
 };
 }  // namespace csi::service::node
 

--- a/src/node_service.h
+++ b/src/node_service.h
@@ -11,7 +11,7 @@ class NodeService final : public csi::v1::Node::Service {
  public:
   NodeService(
       csi::service::Config const &config,
-      std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities);
+      std::vector<csi::v1::NodeServiceCapability_RPC_Type> capabilities);
   NodeService(const NodeService &) = delete;
   NodeService &operator=(const NodeService &) = delete;
   ~NodeService();
@@ -50,7 +50,7 @@ class NodeService final : public csi::v1::Node::Service {
 
  private:
   csi::service::Config const &config_;
-  std::vector<csi::v1::NodeServiceCapability_RPC_Type> const &capabilities_;
+  std::vector<csi::v1::NodeServiceCapability_RPC_Type> capabilities_;
 };
 }  // namespace csi::service::node
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -48,7 +48,7 @@ void Server::Run() {
   grpc::ServerBuilder builder;
   builder.AddListeningPort(config().endpoint(),
                            grpc::InsecureServerCredentials());
-  node::NodeService node_service(config());
+  node::NodeService node_service(config(), node_capabilities_);
   identity::IdentityService identity_service(config());
   controller::ControllerService controller_service(config());
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -14,8 +14,35 @@
 
 namespace csi {
 namespace service {
-Server::Server(Config config) : config_(config) {}
+Server::Server(Config config) : config_(config) {
+  this->AddNodeCapabilities(
+      std::vector<csi::v1::NodeServiceCapability_RPC_Type>{
+          csi::v1::NodeServiceCapability_RPC_Type::
+              NodeServiceCapability_RPC_Type_GET_VOLUME_STATS,
+          csi::v1::NodeServiceCapability_RPC_Type::
+              NodeServiceCapability_RPC_Type_UNKNOWN,
+      });
+  this->AddControllerCapabilities(
+      std::vector<csi::v1::ControllerServiceCapability_RPC_Type>{
+          csi::v1::ControllerServiceCapability_RPC_Type::
+              ControllerServiceCapability_RPC_Type_CREATE_DELETE_VOLUME,
+          csi::v1::ControllerServiceCapability_RPC_Type::
+              ControllerServiceCapability_RPC_Type_UNKNOWN,
+      });
+}
 Server::~Server() {}
+
+void Server::AddControllerCapabilities(
+    std::vector<csi::v1::ControllerServiceCapability_RPC_Type> types) {
+  controller_capabilities_.insert(controller_capabilities_.end(), types.begin(),
+                                  types.end());
+}
+
+void Server::AddNodeCapabilities(
+    std::vector<csi::v1::NodeServiceCapability_RPC_Type> types) {
+  node_capabilities_.insert(node_capabilities_.end(), types.begin(),
+                            types.end());
+}
 
 void Server::Run() {
   grpc::ServerBuilder builder;

--- a/src/service.cc
+++ b/src/service.cc
@@ -34,23 +34,22 @@ Server::~Server() {}
 
 void Server::AddControllerCapabilities(
     std::vector<csi::v1::ControllerServiceCapability_RPC_Type> types) {
-  controller_capabilities_.insert(controller_capabilities_.end(), types.begin(),
-                                  types.end());
+  controller_capabilities_ = types;
 }
 
 void Server::AddNodeCapabilities(
     std::vector<csi::v1::NodeServiceCapability_RPC_Type> types) {
-  node_capabilities_.insert(node_capabilities_.end(), types.begin(),
-                            types.end());
+  node_capabilities_ = types;
 }
 
 void Server::Run() {
   grpc::ServerBuilder builder;
   builder.AddListeningPort(config().endpoint(),
                            grpc::InsecureServerCredentials());
-  node::NodeService node_service(config(), node_capabilities_);
+  node::NodeService node_service(config(), node_capabilities());
   identity::IdentityService identity_service(config());
-  controller::ControllerService controller_service(config());
+  controller::ControllerService controller_service(config(),
+                                                   controller_capabilities());
 
   builder.RegisterService(&node_service);
   builder.RegisterService(&identity_service);

--- a/src/service.cc
+++ b/src/service.cc
@@ -27,6 +27,7 @@ void Server::Run() {
 
   builder.RegisterService(&node_service);
   builder.RegisterService(&identity_service);
+  builder.RegisterService(&controller_service);
 
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
   PLOG_INFO << "Listening on " << config().endpoint();

--- a/src/service.h
+++ b/src/service.h
@@ -1,7 +1,11 @@
 #ifndef CSI_DRIVER_CHFS_SERVICE_HPP_
 #define CSI_DRIVER_CHFS_SERVICE_HPP_
 
+#include <csi.grpc.pb.h>
+#include <csi.pb.h>
+
 #include <string>
+#include <vector>
 
 #include "config.h"
 
@@ -15,9 +19,26 @@ class Server {
 
   Config &config() { return config_; }
   const Config &config() const { return config_; }
+  const std::vector<csi::v1::ControllerServiceCapability_RPC_Type> &
+  controller_capabilities() {
+    return controller_capabilities_;
+  }
+  const std::vector<csi::v1::NodeServiceCapability_RPC_Type> &
+  node_capabilities() const {
+    return node_capabilities_;
+  }
+
+  void AddControllerCapabilities(
+      std::vector<csi::v1::ControllerServiceCapability_RPC_Type> types);
+
+  void AddNodeCapabilities(
+      std::vector<csi::v1::NodeServiceCapability_RPC_Type> types);
 
  private:
   Config config_;
+  std::vector<csi::v1::ControllerServiceCapability_RPC_Type>
+      controller_capabilities_;
+  std::vector<csi::v1::NodeServiceCapability_RPC_Type> node_capabilities_;
 };
 }  // namespace service
 }  // namespace csi


### PR DESCRIPTION
# 概要

NodeService の NodeGetInfo を実装した。

# 動作確認

* server
```
$ ./build/src/main -i 1
```

* client

```
$ csi-sanity --csi.endpoint unix:/tmp/csi.sock --ginkgo.focus NodeGetInfo
Running Suite: CSI Driver Test Suite - /workspaces/csi-driver-chfs
==================================================================
Random Seed: 1702813561

Will run 1 of 84 specs
SSSSS
------------------------------
P [PENDING]
Controller Service [Controller Server] ListVolumes pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted
/go/pkg/mod/github.com/kubernetes-csi/csi-test/v5@v5.2.0/pkg/sanity/controller.go:268
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 84 Specs in 0.012 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 82 Skipped
```