### PR TITLE
rpath の設定

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set(CMAKE_INSTALL_RPATH "${CHFS_LIBRARY_DIRS}")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(main
     main.cc
     service.cc
@@ -11,8 +15,11 @@ target_link_libraries(main
     csi_proto
     csi_grpc_proto
     plog
-    ${CHFS_LIBS}
     ${_REFLECTION}
     ${_GRPC_GRPCPP}
     ${_PROTOBUF_LIBPROTOBUF}
+    ${CHFS_LDFLAGS}
+    ${MARGO_LDFLAGS}
 )
+target_compile_options(main PUBLIC ${CHFS_CFLAGS_OTHER})
+install(TARGETS main RUNTIME DESTINATION .)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(main
     csi_proto
     csi_grpc_proto
     plog
-    ${CHFS_LIBRARIES}
+    ${CHFS_LIBS}
     ${_REFLECTION}
     ${_GRPC_GRPCPP}
     ${_PROTOBUF_LIBPROTOBUF}

--- a/src/config.cc
+++ b/src/config.cc
@@ -3,11 +3,13 @@
 namespace csi {
 namespace service {
 Config::Config(const std::string endpoint, const std::string driver_name,
-               const std::string node_id, const std::string version)
+               const std::string node_id, const std::string version,
+               const std::string server_address)
     : endpoint_(endpoint),
       driver_name_(driver_name),
       node_id_(node_id),
-      version_(version) {}
+      version_(version),
+      server_address_(server_address) {}
 Config::~Config() {}
 }  // namespace service
 }  // namespace csi

--- a/src/config.h
+++ b/src/config.h
@@ -8,19 +8,22 @@ namespace service {
 class Config {
  public:
   Config(const std::string endpoint, const std::string driver_name,
-         const std::string node_id, const std::string version);
+         const std::string node_id, const std::string version,
+         const std::string server_address);
   ~Config();
 
   const std::string &driver_name() const { return driver_name_; }
   const std::string &endpoint() const { return endpoint_; }
   const std::string &node_id() const { return node_id_; }
   const std::string &version() const { return version_; }
+  const std::string &server_address() const { return server_address_; }
 
  private:
   std::string driver_name_;
   std::string endpoint_;
   std::string node_id_;
   std::string version_;
+  std::string server_address_;
 };
 
 }  // namespace service

--- a/src/main.cc
+++ b/src/main.cc
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     ("n,driver-name", "name of this CSI driver",
       cxxopts::value<std::string>()->default_value("chfsplugin"))
     ("i,node-id", "node id",
-      cxxopts::value<std::string>()->default_value(""))
+      cxxopts::value<std::string>()->default_value("0"))
     ("s,chfs-server", "chfs server address", cxxopts::value<std::string>()->default_value(""))
   ;
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -1,5 +1,10 @@
 #include "service.h"
 
+#ifdef __cplusplus
+extern "C" {
+#include <chfs.h>
+}
+#endif
 #include <grpc/grpc.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
@@ -55,7 +60,10 @@ void Server::Run() {
 
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
   PLOG_INFO << "Listening on " << config().endpoint();
+
+  chfs_init(config().server_address().c_str());
   server->Wait();
+  chfs_term();
 }
 }  // namespace service
 }  // namespace csi


### PR DESCRIPTION
# 背景

Spack では `LD_LIBRARY_PATH` が `spack load` で公開されないようになっていた。
一方で、margo や chfs は LD_LIBRARY_PATH を前提に環境構築をしている。
以上により、直接インストールしている chfs は LD_LIBRARY_PATH によるロードが可能であるが、spack 配下の margo はロードできない状態で実行に失敗する。

# 解決策

- rpath を使ったリンクを行う

# 動作確認

```sh
# build by cmake tools for vscode
$ cmake --build /workspaces/csi-driver-chfs/build --config Debug --target all -j 8
$ sudo cmake --install . --prefix /tmp/local
```